### PR TITLE
fix syntax error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ ensured_targets = [
 labext_name = "rise-jupyterlab"
 
 INSTALL_REQUIRES = [
-    "jupyter_server>=1.6,<2"
+    "jupyter_server>=1.6,<2",
     "jupyterlab>=3,<4"
 ]
 


### PR DESCRIPTION
Fix error when running docker image building: 
`error in rise setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)`